### PR TITLE
Remove src directory from .npmigore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,4 +7,3 @@ screenshot.png
 webpack.config.js
 webpack.dist.js
 lib
-src


### PR DESCRIPTION
I'm having an issue with eslint when I import this package. 
It is giving me an error: "Unable to resolve path to module 'react-chatview'."

The reason for this is, I think, in the `package.json` the `jsnext:main` entry point is looking in the src directory, which is not shipped as its listed in the `.npmignore` file. 

This removes the `src` ignore from `.npmignore`

Fixes #28 
